### PR TITLE
Bug：サーバーサイドで退出したユーザーを検知ときに、他の部屋のメンバーが映るバグを解消

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,15 +29,18 @@ io.on("connection", (socket) => {
       lists = lists.filter((list) => { return list !== preScore[0] })
     }
 
-    io.in(roomUid).emit("receivedScore", lists.filter((e) => {
-      return e.data.roomUid == roomUid
+    io.in(roomUid).emit("receivedScore", lists.filter((list) => {
+      return list.data.roomUid == roomUid
     }))
   })
 
   socket.on("logOutRoom", (res) => {
     const roomUid = res.data.roomUid
     lists = lists.filter((list) => list.data.userName !== res.data.userName)
-    io.in(roomUid).emit("receivedScore", lists)
+    io.in(roomUid).emit("receivedScore", lists.filter((list) => {
+      return list.data.roomUid == roomUid
+    }))
+    socket.leave(roomUid)
   })
 
   socket.on("openScoreRequest", (res) => {


### PR DESCRIPTION
#6 

# やったこと
ログインしたユーザーを検知したとき（logOutRoomが呼ばれたとき）、送信する```list```の値に全く異なる部屋の参加者が含まれていたので、修正

https://user-images.githubusercontent.com/76689059/190105111-72362c42-6aed-4386-bbe4-3dcae796e905.mov
